### PR TITLE
Static curl

### DIFF
--- a/descriptors/bitshares-core-linux.yml
+++ b/descriptors/bitshares-core-linux.yml
@@ -16,13 +16,13 @@ packages:
 - automake
 - doxygen
 - libboost1.65-all-dev
-- libcurl4-openssl-dev
 - libssl-dev
 remotes:
 - url: https://github.com/bitshares/bitshares-core.git
   dir: bitshares
 files:
 - supplement.tar.gz
+- curl-7.65.3.tar.bz2
 script: |
   set -e -o pipefail
 
@@ -44,7 +44,25 @@ script: |
   else
     export CCACHE_DISABLE=true
   fi
+
+  mkdir lib
+  LIBS="`pwd`/lib"
   
+  # Build curl
+  CURL="`echo curl-*`"
+  tar xfj "$CURL"
+  pushd "${CURL%.tar.bz2}"
+  PKG_CONFIG_PATH="$LIBS/lib/pkgconfig" ./configure --prefix="$LIBS" \
+                                                    --disable-shared \
+                                                    --disable-tftpf \
+                                                    --disable-ldap \
+                                                    --with-zlib \
+                                                    --with-ssl \
+                                                    --disable-tftp \
+                                                    --disable-ldap
+  make $MAKEOPTS install
+  popd
+
   cd bitshares
   cp libraries/wallet/wallet.cpp{,.orig}
   sed -i '/__DATE__/d' libraries/wallet/wallet.cpp
@@ -58,6 +76,7 @@ script: |
         -D CMAKE_C_COMPILER_LAUNCHER=ccache \
         -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
         -D CURL_STATICLIB=true \
+        -D CMAKE_FIND_ROOT_PATH="$LIBS" \
         ..
   make $MAKEOPTS witness_node cli_wallet
 

--- a/descriptors/bitshares-core-linux.yml
+++ b/descriptors/bitshares-core-linux.yml
@@ -57,6 +57,7 @@ script: |
   cmake -D CMAKE_BUILD_TYPE=Release \
         -D CMAKE_C_COMPILER_LAUNCHER=ccache \
         -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -D CURL_STATICLIB=true \
         ..
   make $MAKEOPTS witness_node cli_wallet
 

--- a/run-gitian
+++ b/run-gitian
@@ -28,6 +28,19 @@ fi
 
 if [ -n "$BUILD" ]; then
     tar cfz inputs/supplement.tar.gz -C ../.. supplement
+
+    while read url sha; do
+        FILE="${url##*/}"
+        if [ ! -r "inputs/$FILE" ]; then
+            echo "Downloading $FILE..."
+            ( cd inputs; curl -LO "$url" )
+        fi
+        sha256sum "inputs/$FILE" \
+          | grep -q "$sha" \
+          || ( echo "inputs/$FILE is wrong!?" 1>&2 && exit 1 )
+    done <<_EOL_
+https://curl.haxx.se/download/curl-7.65.3.tar.bz2 0a855e83be482d7bc9ea00e05bdb1551a44966076762f9650959179c89fce509
+_EOL_
 fi
 
 if [ "$#" -lt 1 ]; then


### PR DESCRIPTION
Build and link static libcurl to reduce external dependencies.
Requires https://github.com/bitshares/bitshares-core/pull/1872 .